### PR TITLE
Squashed commit of the following:

### DIFF
--- a/functions/ai/openai/dallE.js
+++ b/functions/ai/openai/dallE.js
@@ -15,7 +15,10 @@ import {
 } from "../imageGen.js";
 
 import {geminiRequest} from "../gemini/gemini.js";
-import {queueAddEntries} from "../../storage/firestore/queue.js";
+import {
+  queueAddEntries,
+  dalleQueueToUnique,
+} from "../../storage/firestore/queue.js";
 
 
 const OPENAI_DALLE_3_IMAGES_PER_MINUTE = 200;
@@ -165,10 +168,19 @@ async function addSceneToQueue(params) {
   const types = ["dalle"];
   const entryTypes = ["dalle3"];
   const entryParams = [{scene, sceneId, retry}];
+  const uniques = [dalleQueueToUnique({
+    type: "dalle",
+    entryType: "dalle3",
+    sceneId,
+    chapter: scene.chapter,
+    scene_number: scene.scene_number,
+    retry,
+  })];
   await queueAddEntries({
     types,
     entryTypes,
     entryParams,
+    uniques,
   });
 }
 

--- a/functions/routes/pipeline.js
+++ b/functions/routes/pipeline.js
@@ -39,7 +39,7 @@ export const processM4B = onTaskDispatched(
 );
 
 export const generateSceneImages = onTaskDispatched(
-    mediumDispatchInstance(),
+    mediumDispatchInstance(50),
     async (req) => {
       logger.debug(`generateSceneImages: ${JSON.stringify(req.data)}`);
       return await imageGenChapterRecursive(dataToBody(req));
@@ -47,7 +47,7 @@ export const generateSceneImages = onTaskDispatched(
 );
 
 export const generateSceneImagesCurrentTime = onTaskDispatched(
-    mediumDispatchInstance(),
+    mediumDispatchInstance(50),
     async (req) => {
       logger.debug(`generateSceneImagesCurrentTime: ${JSON.stringify(req.data)}`);
       return await imageGenCurrentTime(dataToBody(req));

--- a/functions/test/01.init.test.js
+++ b/functions/test/01.init.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable require-jsdoc */
 
 /* eslint-disable no-unused-vars */
 /* eslint-disable max-len */
@@ -74,6 +75,25 @@ const auth = getAuth();
 
 const TEST_USER_EMAIL = `john.${Date.now()}@example.com`;
 const AAX_TESTS = false;
+
+
+async function callStabilityQueue() {
+  console.log(`Calling launchStabilityQueue manually`);
+  const response = await chai
+      .request(`${DISPATCH_URL}/${APP_ID}/${DISPATCH_REGION}`)
+      .post("/launchStabilityQueue").set("Content-Type", "application/json")
+      .send({data: {}});
+  return response;
+}
+
+async function callDalleQueue() {
+  console.log(`Calling launchDalleQueue manually`);
+  const response = await chai
+      .request(`${DISPATCH_URL}/${APP_ID}/${DISPATCH_REGION}`)
+      .post("/launchDalleQueue").set("Content-Type", "application/json")
+      .send({data: {}});
+  return response;
+}
 
 // eslint-disable-next-line no-undef
 describe("Full functional tests of visibl api", () => {
@@ -1008,7 +1028,7 @@ describe("Full functional tests of visibl api", () => {
     const lastSceneGenerated = 0;
     const totalScenes = 1;
     const chapter = 0;
-    let response = await chai
+    const response = await chai
         .request(`${DISPATCH_URL}/${APP_ID}/${DISPATCH_REGION}`)
         .post("/generateSceneImages")
         .set("Content-Type", "application/json")
@@ -1016,19 +1036,9 @@ describe("Full functional tests of visibl api", () => {
           data:
             {sceneId, lastSceneGenerated, totalScenes, chapter},
         });
-    // expect(response).to.have.status(204); // Dispatch at end will fail, so not 204.
-    console.log(`Calling launchDalleQueue manually`);
-    response = await chai
-        .request(`${DISPATCH_URL}/${APP_ID}/${DISPATCH_REGION}`)
-        .post("/launchDalleQueue").set("Content-Type", "application/json")
-        .send({data: {}});
-    // expect(response).to.have.status(204); // Dispatch at end will fail, so not 204.
-    console.log(`Calling launchStabilityQueue manually`);
-    response = await chai
-        .request(`${DISPATCH_URL}/${APP_ID}/${DISPATCH_REGION}`)
-        .post("/launchStabilityQueue").set("Content-Type", "application/json")
-        .send({data: {}});
-    expect(response).to.have.status(204);
+
+    await callDalleQueue();
+    expect(await callStabilityQueue()).to.have.status(204);
     // We need to now get the scenes and check that no image is here.
     const wrapped = firebaseTest.wrap(v1getAi);
     let result = await wrapped({
@@ -1053,18 +1063,8 @@ describe("Full functional tests of visibl api", () => {
     expect(result[0]).to.not.have.property("square");
 
     // Now lets see if the moderated image is generated.
-    console.log(`Calling launchDalleQueue manually`);
-    response = await chai
-        .request(`${DISPATCH_URL}/${APP_ID}/${DISPATCH_REGION}`)
-        .post("/launchDalleQueue").set("Content-Type", "application/json")
-        .send({data: {}});
-    // expect(response).to.have.status(204); // Dispatch at end will fail, so not 204.
-    console.log(`Calling launchStabilityQueue manually`);
-    response = await chai
-        .request(`${DISPATCH_URL}/${APP_ID}/${DISPATCH_REGION}`)
-        .post("/launchStabilityQueue").set("Content-Type", "application/json")
-        .send({data: {}});
-    expect(response).to.have.status(204);
+    await callDalleQueue();
+    expect(await callStabilityQueue()).to.have.status(204);
     result = await wrapped({
       auth: {
         uid: userData.uid,
@@ -1092,7 +1092,7 @@ describe("Full functional tests of visibl api", () => {
     const lastSceneGenerated = 0;
     const totalScenes = 6;
     const chapter = 3;
-    let response = await chai
+    const response = await chai
         .request(`${DISPATCH_URL}/${APP_ID}/${DISPATCH_REGION}`)
         .post("/generateSceneImages")
         .set("Content-Type", "application/json")
@@ -1100,33 +1100,11 @@ describe("Full functional tests of visibl api", () => {
           data:
           {sceneId, lastSceneGenerated, totalScenes, chapter},
         });
-    // expect(response).to.have.status(204); // Dispatch at end will fail, so not 204.
-    console.log(`Calling launchDalleQueue manually`);
-    response = await chai
-        .request(`${DISPATCH_URL}/${APP_ID}/${DISPATCH_REGION}`)
-        .post("/launchDalleQueue").set("Content-Type", "application/json")
-        .send({data: {}});
-    // expect(response).to.have.status(204); // Dispatch at end will fail, so not 204.
-    console.log(`Calling launchStabilityQueue manually`);
-    response = await chai
-        .request(`${DISPATCH_URL}/${APP_ID}/${DISPATCH_REGION}`)
-        .post("/launchStabilityQueue").set("Content-Type", "application/json")
-        .send({data: {}});
-    expect(response).to.have.status(204);
+    await callDalleQueue();
+    expect(await callStabilityQueue()).to.have.status(204);
     // Call again in case anything was rejected by content moderation
-    // expect(response).to.have.status(204); // Dispatch at end will fail, so not 204.
-    console.log(`Calling launchDalleQueue manually`);
-    response = await chai
-        .request(`${DISPATCH_URL}/${APP_ID}/${DISPATCH_REGION}`)
-        .post("/launchDalleQueue").set("Content-Type", "application/json")
-        .send({data: {}});
-    // expect(response).to.have.status(204); // Dispatch at end will fail, so not 204.
-    console.log(`Calling launchStabilityQueue manually`);
-    response = await chai
-        .request(`${DISPATCH_URL}/${APP_ID}/${DISPATCH_REGION}`)
-        .post("/launchStabilityQueue").set("Content-Type", "application/json")
-        .send({data: {}});
-    expect(response).to.have.status(204);
+    await callDalleQueue();
+    expect(await callStabilityQueue()).to.have.status(204);
     // We need to now get the scenes and check that an image is generated.
     const wrapped = firebaseTest.wrap(v1getAi);
     const result = await wrapped({
@@ -1155,7 +1133,7 @@ describe("Full functional tests of visibl api", () => {
   // eslint-disable-next-line no-undef
   it(`test generateSceneImagesCurrentTime taskQueue`, async () => {
     const sceneId = addedScene.id;
-    let response = await chai
+    const response = await chai
         .request(`${DISPATCH_URL}/${APP_ID}/${DISPATCH_REGION}`)
         .post("/generateSceneImagesCurrentTime")
         .set("Content-Type", "application/json")
@@ -1165,18 +1143,8 @@ describe("Full functional tests of visibl api", () => {
           // Should be Chapter 30 scene 1.
         });
     // expect(response).to.have.status(204); // Dispatch at end will fail, so not 204.
-    console.log(`Calling launchDalleQueue manually`);
-    response = await chai
-        .request(`${DISPATCH_URL}/${APP_ID}/${DISPATCH_REGION}`)
-        .post("/launchDalleQueue").set("Content-Type", "application/json")
-        .send({data: {}});
-    // expect(response).to.have.status(204); // Dispatch at end will fail, so not 204.
-    console.log(`Calling launchStabilityQueue manually`);
-    response = await chai
-        .request(`${DISPATCH_URL}/${APP_ID}/${DISPATCH_REGION}`)
-        .post("/launchStabilityQueue").set("Content-Type", "application/json")
-        .send({data: {}});
-    expect(response).to.have.status(204);
+    await callDalleQueue();
+    expect(await callStabilityQueue()).to.have.status(204);
 
     // NO IMAGE EXISTS for the styled scene. TODO: Fix this..
     // const wrapped = firebaseTest.wrap(v1getAi);
@@ -1208,7 +1176,7 @@ describe("Full functional tests of visibl api", () => {
     const lastSceneGenerated = 0;
     const totalScenes = 6;
     const chapter = 3;
-    let response = await chai
+    const response = await chai
         .request(`${DISPATCH_URL}/${APP_ID}/${DISPATCH_REGION}`)
         .post("/generateSceneImagesCurrentTime")
         .set("Content-Type", "application/json")
@@ -1218,18 +1186,8 @@ describe("Full functional tests of visibl api", () => {
           // Should be Chapter 30 scene 1.
         });
     // expect(response).to.have.status(204); // Dispatch at end will fail, so not 204.
-    console.log(`Calling launchDalleQueue manually`);
-    response = await chai
-        .request(`${DISPATCH_URL}/${APP_ID}/${DISPATCH_REGION}`)
-        .post("/launchDalleQueue").set("Content-Type", "application/json")
-        .send({data: {}});
-    // expect(response).to.have.status(204); // Dispatch at end will fail, so not 204.
-    console.log(`Calling launchStabilityQueue manually`);
-    response = await chai
-        .request(`${DISPATCH_URL}/${APP_ID}/${DISPATCH_REGION}`)
-        .post("/launchStabilityQueue").set("Content-Type", "application/json")
-        .send({data: {}});
-    expect(response).to.have.status(204);
+    await callDalleQueue();
+    expect(await callStabilityQueue()).to.have.status(204);
   });
   // eslint-disable-next-line no-undef
   it(`test v1getLibraryScenes with a single scene`, async () => {
@@ -1513,7 +1471,7 @@ describe("Full functional tests of visibl api", () => {
       sceneId: styledSceneId,
       currentTime: time,
     };
-    let response = await chai
+    const response = await chai
         .request(`${DISPATCH_URL}/${APP_ID}/${DISPATCH_REGION}`)
         .post("/generateSceneImagesCurrentTime")
         .set("Content-Type", "application/json")
@@ -1521,18 +1479,8 @@ describe("Full functional tests of visibl api", () => {
           data,
         });
     // expect(response).to.have.status(204); // Dispatch at end will fail, so not 204.
-    console.log(`Calling launchDalleQueue manually`);
-    response = await chai
-        .request(`${DISPATCH_URL}/${APP_ID}/${DISPATCH_REGION}`)
-        .post("/launchDalleQueue").set("Content-Type", "application/json")
-        .send({data: {}});
-    // expect(response).to.have.status(204); // Dispatch at end will fail, so not 204.
-    console.log(`Calling launchStabilityQueue manually`);
-    response = await chai
-        .request(`${DISPATCH_URL}/${APP_ID}/${DISPATCH_REGION}`)
-        .post("/launchStabilityQueue").set("Content-Type", "application/json")
-        .send({data: {}});
-    expect(response).to.have.status(204);
+    await callDalleQueue();
+    expect(await callStabilityQueue()).to.have.status(204);
 
     // We need to now get the scenes and check that an image is generated.
     wrapped = firebaseTest.wrap(v1getAi);

--- a/functions/util/dispatch.js
+++ b/functions/util/dispatch.js
@@ -77,15 +77,16 @@ function microDispatchInstance() {
 
 /**
  * @return {Object} An object with a 'body' property containing the request data.
+ * @param {number} concurrency - The number of concurrent dispatches.
  */
-function mediumDispatchInstance() {
+function mediumDispatchInstance(concurrency=1) {
   return {
     retryConfig: {
       maxAttempts: 1,
       minBackoffSeconds: 1,
     },
     rateLimits: {
-      maxConcurrentDispatches: 1,
+      maxConcurrentDispatches: concurrency,
     },
     region: "us-central1",
     memory: "4GiB",


### PR DESCRIPTION
commit 14f31478c07e5929f4a3af38a6cd4d366c50c630
Author: Moe Adham <moeadham@gmail.com>
Date:   Fri Aug 30 15:35:57 2024 +0100

    [queue] dedup

    No duplicates in queue

commit 5fdc254e7501b84c9a7ff8dc964bee186b78605e
Author: Moe Adham <moeadham@gmail.com>
Date:   Thu Aug 29 17:42:27 2024 +0100

    [dalle] handle non safety failures

commit 2aa2980d474fdba4ec564d67b803cb29d854e0e0
Author: Moe Adham <moeadham@gmail.com>
Date:   Thu Aug 29 17:24:03 2024 +0100

    [dalle] moderation added

    Will now retry to create a dall-e image once if
    it is rejected by their safety system, using gemini
    to moderate the prompt.

commit 49ed162f6cd545ce38ab545025d284761771c96a
Author: Moe Adham <moeadham@gmail.com>
Date:   Thu Aug 29 14:45:42 2024 +0100

    [dispatch] pare down some memory

commit 671f40576e977a415d1b36ccc6eefd53202242d1
Author: Moe Adham <moeadham@gmail.com>
Date:   Thu Aug 29 14:40:55 2024 +0100

    [queue] dalle queue implementation

    Should tidy up taskQueue for old stuff, but it may
    make the app responseive to keep the queue entry system
    in a dispatch. We'll see.

commit ab58c88b72b65d330f2bb36406aaf05b7b772a14
Author: Moe Adham <moeadham@gmail.com>
Date:   Thu Aug 29 12:06:18 2024 +0100

    [queue] stability tasks

    Stability tasks are now in a proper queue
    Dispatch is a bit dumb right now because you dispatch the
    old imageGen, which dispatches the queue.

    Next step is to move dall-e to the queue as well, then we can have
    a single dispatch model.

commit 3a0b794513bb45702343bd06a7c831f66e051c90
Author: Moe Adham <moeadham@gmail.com>
Date:   Wed Aug 28 17:22:08 2024 +0100

    [queue] minor improvements

commit 869d39c9a20cf852ada74a7443b2f8b609130f3a
Author: Moe Adham <moeadham@gmail.com>
Date:   Wed Aug 28 17:12:08 2024 +0100

    [queue] functional queue system for stability

commit 9dd08c520c51dd9b381e58a3d3473fc5b328d0b0
Author: Moe Adham <moeadham@gmail.com>
Date:   Wed Aug 28 12:21:59 2024 +0100

    [queue] intial CRUD for the queue.

    Next step is the actual dispatch job to process &
    clear the queue

commit ce14ea730c018abed8475d9154da2a73d028f440
Merge: 11e1f20 dcbb23a
Author: Moe <moeadham@gmail.com>
Date:   Wed Aug 28 10:10:28 2024 +0100

    Merge pull request #11 from visibl-ai/merge

    Squashed commit of the following: